### PR TITLE
Ux improvements

### DIFF
--- a/Helpers/ItemRenderer.cs
+++ b/Helpers/ItemRenderer.cs
@@ -101,7 +101,7 @@ namespace NavigationBar.Helpers
 
         static void DrawItemBackground(ComboBox comboBox, DrawItemEventArgs e)
         {
-            Color backColor;
+            Color backColor = Color.Empty;
 
             if (e.Bounds.X == 0)
                 backColor = PluginBase.MainForm.GetThemeColor("ToolStripMenu.BackColor");


### PR DESCRIPTION
MultiKey search improvements:
- Fixed forward search starting on next item instead of the current one. It would cause some erroneous jumping.
- Avoid propagating the key press to the combo control, it could cause wrong behaviour, also resulting on the selected item to jump around.
- If the user keeps pressing the same key, wrap around similar entries like in Visual Studio. It makes searching for items more comfortable. Maybe the code could be optimized by checking if the current ítem matches the original word and so avoid to perform any further search with all the other elements.

Also fixed compilation.
